### PR TITLE
Reset lastEncounter before repeating from NC

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -7,6 +7,7 @@ import {
   have,
   isSong,
   PropertiesManager,
+  set,
   uneffect,
 } from "libram";
 import {

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -103,7 +103,10 @@ export class Engine<A extends string = never, T extends Task<A> = Task<A>> {
     for (const resource of task_resources.all()) resource.prepare?.();
     this.prepare(task);
     this.do(task);
-    while (this.shouldRepeatAdv(task)) this.do(task);
+    while (this.shouldRepeatAdv(task)) {
+      set("lastEncounter", "");
+      this.do(task);
+    }
     this.post(task);
 
     // Mark that we tried the task, and apply limits


### PR DESCRIPTION
This avoids a bad infinite loop if lastEncounter is not being set by task.do