### PR TITLE
Add modes parameter to OutfitSpec

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -231,6 +231,7 @@ export class Engine<A extends string = never, T extends Task<A> = Task<A>> {
       if (spec?.familiar !== undefined) {
         if (!outfit.equip(spec.familiar)) throw `Unable to equip familiar ${spec.familiar}`;
       }
+      outfit.modes = spec?.modes ?? {};
       outfit.avoid = spec?.avoid;
       outfit.skipDefaults = spec?.skipDefaults ?? false;
       outfit.modifier = spec?.modifier;

--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -1,10 +1,12 @@
 import {
   booleanModifier,
   canEquip,
+  cliExecute,
   equip,
   equippedAmount,
   equippedItem,
   Familiar,
+  haveEquipped,
   Item,
   weaponHands as mafiaWeaponHands,
   myFamiliar,
@@ -13,12 +15,14 @@ import {
   useFamiliar,
 } from "kolmafia";
 import { $familiar, $item, $skill, $slot, $slots, have, Requirement } from "libram";
+import { modeables, Modes } from "./task";
 
 const weaponHands = (i?: Item) => (i ? mafiaWeaponHands(i) : 0);
 
 export class Outfit {
   equips: Map<Slot, Item> = new Map<Slot, Item>();
   accessories: Item[] = [];
+  modes: Modes = {};
   skipDefaults = false;
   familiar?: Familiar;
   modifier?: string;
@@ -217,6 +221,14 @@ export class Outfit {
       }
     }
 
+    for (const mode in this.modes) {
+      if (haveEquipped(modeables[mode as keyof Modes])) {
+        const cmd = this.modes[mode as keyof Modes];
+        const args = Array.isArray(cmd) ? cmd.join(" ") : cmd;
+        cliExecute(`${mode} ${args}`);
+      }
+    }
+
     if (
       (this.familiar !== undefined && myFamiliar() !== this.familiar) ||
       ![...this.equips].every(([slot, item]) => equippedItem(slot) === item) ||
@@ -232,6 +244,7 @@ export class Outfit {
     const result = new Outfit();
     result.equips = new Map(this.equips);
     result.accessories = [...this.accessories];
+    result.modes = { ...this.modes };
     result.skipDefaults = this.skipDefaults;
     result.familiar = this.familiar;
     result.modifier = this.modifier;

--- a/src/task.ts
+++ b/src/task.ts
@@ -28,6 +28,7 @@ export const modeables = {
   snowsuit: $item`Snow Suit`,
   edpiece: $item`The Crown of Ed the Undying`,
   retrocape: $item`unwrapped knock-off retro superhero cape`,
+	parka: $item`Jurassic Parka`,
 } as const;
 
 export const outfitSlots = [

--- a/src/task.ts
+++ b/src/task.ts
@@ -1,5 +1,5 @@
 import { Effect, Familiar, Item, Location } from "kolmafia";
-import { get } from "libram";
+import { $item, get } from "libram";
 import { StringProperty } from "libram/dist/propertyTypes";
 import { CombatStrategy } from "./combat";
 
@@ -8,6 +8,22 @@ export type Quest<T> = {
   completed?: () => boolean;
   tasks: T[];
 };
+
+export type Modes = {
+  backupcamera?: "ml" | "meat" | "init";
+  umbrella?: "broken" | "forward" | "bucket" | "pitchfork" | "twirling" | "cocoon";
+  snowsuit?: "eyebrows" | "smirk" | "nose" | "goatee" | "hat";
+  edpiece?: "bear" | "owl" | "puma" | "hyena" | "mouse" | "weasel" | "fish";
+  retrocape?: ["vampire" | "heck" | "robot", "hold" | "thrill" | "kiss" | "kill"];
+};
+
+export const modeables = {
+  backupcamera: $item`backup camera`,
+  umbrella: $item`unbreakable umbrella`,
+  snowsuit: $item`Snow Suit`,
+  edpiece: $item`The Crown of Ed the Undying`,
+  retrocape: $item`unwrapped knock-off retro superhero cape`,
+} as const;
 
 export const outfitSlots = [
   "hat",
@@ -28,6 +44,7 @@ export type OutfitEquips = Partial<{ [slot in OutfitSlot]: Item | Item[] }>;
 
 export interface OutfitSpec extends OutfitEquips {
   equip?: Item[]; // Items to be equipped in any slot
+  modes?: Modes; // Modes to set on particular items
   modifier?: string; // Modifier to maximize
   familiar?: Familiar; // Familiar to use
   avoid?: Item[]; // Items that cause issues and so should not be equipped

--- a/src/task.ts
+++ b/src/task.ts
@@ -19,6 +19,7 @@ export type Modes = {
     | "vampire"
     | "heck"
     | "robot";
+parka?: "kachungasaur" | "dilophosaur" | "ghostasaurus" | "spikolodon" | "pterodactyl";
 };
 
 export const modeables = {

--- a/src/task.ts
+++ b/src/task.ts
@@ -14,7 +14,11 @@ export type Modes = {
   umbrella?: "broken" | "forward" | "bucket" | "pitchfork" | "twirling" | "cocoon";
   snowsuit?: "eyebrows" | "smirk" | "nose" | "goatee" | "hat";
   edpiece?: "bear" | "owl" | "puma" | "hyena" | "mouse" | "weasel" | "fish";
-  retrocape?: ["vampire" | "heck" | "robot", "hold" | "thrill" | "kiss" | "kill"];
+  retrocape?:
+    | ["vampire" | "heck" | "robot", "hold" | "thrill" | "kiss" | "kill"]
+    | "vampire"
+    | "heck"
+    | "robot";
 };
 
 export const modeables = {


### PR DESCRIPTION
Borrowed from phccs. Should we validate that we have the proper mode set at the end of `.dress()`?