### PR TITLE
Allow for equipping duplicate accessories by specifying slots

### DIFF
--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -161,7 +161,7 @@ export class Outfit {
       if (itemOrItems !== undefined && !this.equip(itemOrItems, slot)) succeeded = false;
     }
     for (const item of spec?.equip ?? []) {
-      if (!this.equipItem(item)) succeeded = false;
+      if (!this.equip(item)) succeeded = false;
     }
     if (spec?.familiar !== undefined) {
       if (!this.equip(spec.familiar)) succeeded = false;

--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -259,7 +259,7 @@ export class Outfit {
     // To plan how to equip accessories, first check which accessories are
     // already equipped in some accessory slot. There is no need to move them,
     // since KoL doesn't care what order accessories are equipped in.
-    const missingAccessories = [];
+    const missingAccessories = []; // accessories that are not already equipped
     for (const accessory of accessoryEquips) {
       const alreadyEquipped = accessorySlots.find(
         (slot) => !usedSlots.has(slot) && equippedItem(slot) === accessory

--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -288,7 +288,6 @@ export class Outfit {
       const allRequirements = [
         new Requirement([this.modifier], {
           preventSlot: [...usedSlots],
-          forceEquip: accessoryEquips,
           preventEquip: this.avoid,
         }),
       ];


### PR DESCRIPTION
This PR removes some of the special handling of accessories in the outfit planning. The goal is to allow for duplicate accessories to be specified in the outfit spec, e.g. 
```
const spec = {
    acc1: $item`teacher's pen`,
    acc2: $item`teacher's pen`,
    acc3: $item`teacher's pen`,
};
```

Conceptually this PR changes the internal accessory handling to treat them like any other slot when a slot is specified. Thus in the new PR:
 - ``outfit.equip(acc_item)`` will equip the accessory in the first free slot of acc1, acc2, acc3. This is the same as before.
 - ``outfit.equip(acc_item, $slot`acc1`); outfit.equip(acc_item2, $slot`acc1`);`` will equip acc_item specifically in the first accessory slot, and the second call will return false.  This is different than before (previously this would put both acc_item and acc_item2 in the first free slots).
 - ``outfit.equip(acc_item, $slot`acc1`); outfit.equip(acc_item, $slot`acc2`);`` will now equip acc_item twice. (Previously it would only equip it once).

Accessory slots are still considered fungible in the .dress() function, when actually interacting with KoL. So the equipping behavior should be unchanged.