### PR TITLE
Add support for dark mode in help

### DIFF
--- a/src/args.ts
+++ b/src/args.ts
@@ -591,7 +591,9 @@ export class Args {
       (arg, key) => {
         if (arg.hidden) return;
 
-        const nameText = `<font color='${isDarkMode() ? "yellow" : "blue"}'>${arg.key ?? key}</font>`;
+        const nameText = `<font color='${isDarkMode() ? "yellow" : "blue"}'>${
+          arg.key ?? key
+        }</font>`;
         const valueText =
           arg.valueHelpName === "FLAG" ? "" : `<font color='purple'>${arg.valueHelpName}</font>`;
         const helpText = arg.help ?? "";

--- a/src/args.ts
+++ b/src/args.ts
@@ -4,6 +4,7 @@ import {
   ClassType,
   Effect,
   Familiar,
+  isDarkMode,
   Item,
   Location,
   Monster,
@@ -590,7 +591,7 @@ export class Args {
       (arg, key) => {
         if (arg.hidden) return;
 
-        const nameText = `<font color='blue'>${arg.key ?? key}</font>`;
+        const nameText = `<font color='${isDarkMode() ? "yellow" : "blue"}'>${arg.key ?? key}</font>`;
         const valueText =
           arg.valueHelpName === "FLAG" ? "" : `<font color='purple'>${arg.valueHelpName}</font>`;
         const helpText = arg.help ?? "";


### PR DESCRIPTION
Yellow text is more readable on dark backgrounds compared to blue.