### PR TITLE
Let tasks use a () => Location for do

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -312,11 +312,8 @@ export class Engine<A extends string = never, T extends Task<A> = Task<A>> {
    * @param task The current executing task.
    */
   do(task: T): void {
-    if (typeof task.do === "function") {
-      task.do();
-    } else {
-      adv1(task.do, 0, "");
-    }
+    const result = typeof task.do === "function" ? task.do() : task.do;
+    if (result instanceof Location) adv1(result, -1, "");
     runCombat();
     while (inMultiFight()) runCombat();
     if (choiceFollowsFight()) runChoice(-1);

--- a/src/task.ts
+++ b/src/task.ts
@@ -33,7 +33,7 @@ export type Task<A extends string = never> = {
   //  2. adv1(do) OR do();
   //  3. post();
   prepare?: () => void;
-  do: Location | (() => void);
+  do: Location | (() => unknown);
   post?: () => void;
 
   acquire?: AcquireItem[] | (() => AcquireItem[]);


### PR DESCRIPTION
I have for this two warnings:
1. Using a () => Location will not perfectly replicate the behavior of using a Location; there are several places where we check `task.do instanceof Location` for making decisions. Most notably, setting Location before dressing, and deciding whether to repeat ourselves. I could work around this by making Task be, like, `BaseTask & ( { target: Delayed<Location>, do?: () => void} | { target?: Delayed<Location>, do: () => void })`, but that would be a breaking change for some existing scripts. I think?
2. I switched from 0 to -1 in adv1, because I feel like I never see people use 0 and always see people use -1. This was an accident, but one I won't revert unless told to do so.