### PR TITLE
Make behavior consistent when equipping slotfully and slotlessly

### DIFF
--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -352,6 +352,9 @@ export class Outfit {
    * @returns True if one of the things is equipped, and false otherwise.
    */
   public equipFirst(things: Item[] | Familiar[], slot?: Slot): boolean {
+    // some() returns false on an empty array, yet every() returns true.
+    // This keeps behavior consistent between slotful and slotless equipping.
+    if (things.length < 1) return true;
     return things.some((val) => this.equip(val, slot));
   }
 

--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -354,7 +354,7 @@ export class Outfit {
   public equipFirst(things: Item[] | Familiar[], slot?: Slot): boolean {
     // some() returns false on an empty array, yet every() returns true.
     // This keeps behavior consistent between slotful and slotless equipping.
-    if (things.length < 1) return true;
+    if (things.length === 0) return true;
     return things.some((val) => this.equip(val, slot));
   }
 


### PR DESCRIPTION
Somewhat unexpected behavior:
```js
> js [].every((e)=>true);

Returned: true

> js [].some((e) => true);

Returned: false
```
By short circuiting this we get consistent equipping success/failure for both equipping an empty array with and without a slot specified.