### PR TITLE
Allow assigning choice adventures to string values

### DIFF
--- a/src/task.ts
+++ b/src/task.ts
@@ -38,7 +38,7 @@ export type Task<A extends string = never> = {
 
   acquire?: AcquireItem[] | (() => AcquireItem[]);
   effects?: Effect[] | (() => Effect[]);
-  choices?: { [id: number]: (string | number) | (() => string | number) };
+  choices?: { [id: number]: (number | string) | (() => number | string) };
   limit?: Limit;
   outfit?: OutfitSpec | Outfit | (() => OutfitSpec | Outfit);
   combat?: CombatStrategy<A>;

--- a/src/task.ts
+++ b/src/task.ts
@@ -38,7 +38,7 @@ export type Task<A extends string = never> = {
 
   acquire?: AcquireItem[] | (() => AcquireItem[]);
   effects?: Effect[] | (() => Effect[]);
-  choices?: { [id: number]: number | (() => number) };
+  choices?: { [id: number]: (string | number) | (() => string | number) };
   limit?: Limit;
   outfit?: OutfitSpec | Outfit | (() => OutfitSpec | Outfit);
   combat?: CombatStrategy<A>;


### PR DESCRIPTION
For example this can enable the usage of
```ts
choices: { 1435: () => `1&heyscriptswhatsupwinkwink=${monster.id}` }
```
for [Leading Yourself Right to Them](https://kol.coldfront.net/thekolwiki/index.php/Leading_Yourself_Right_to_Them)