### PR TITLE
BREAKING CHANGE: Delay the choices object differently

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -267,9 +267,9 @@ export class Engine<A extends string = never, T extends Task<A> = Task<A>> {
    * @param manager The property manager to use.
    */
   setChoices(task: T, manager: PropertiesManager): void {
-    for (const [key, func] of Object.entries(task.choices ?? {})) {
-      if (func === undefined) continue;
-      manager.setChoice(parseInt(key), undelay(func));
+    for (const [key, value] of Object.entries(undelay(task.choices ?? {}))) {
+      if (value === undefined) continue;
+      manager.setChoice(parseInt(key), value);
     }
   }
 

--- a/src/task.ts
+++ b/src/task.ts
@@ -38,7 +38,7 @@ export type Task<A extends string = never> = {
 
   acquire?: Delayed<AcquireItem[]>;
   effects?: Delayed<Effect[]>;
-  choices?: { [id: number]: Delayed<number | string> };
+  choices?: Delayed<{ [id: number]: number | string }>;
   limit?: Limit;
   outfit?: Delayed<OutfitSpec | Outfit>;
   combat?: CombatStrategy<A>;


### PR DESCRIPTION
This gives users a lot more flexibility in defining the choices used by a task; in particular, it lets us select arbitrary KVPs instead of just assigning arbitrary values to existing keys