### PR TITLE
Add better error messages when Outfit construction fails.

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -220,8 +220,10 @@ export class Engine<A extends string = never, T extends Task<A> = Task<A>> {
 
     const outfit = new Outfit();
     if (spec !== undefined) {
-      if (!outfit.equip(spec) && !this.options.allow_partial_outfits) {
-        throw `Unable to equip all items for ${task.name}`;
+      if (this.options.allow_partial_outfits) {
+        outfit.equip(spec); // ignore return value
+      } else {
+        outfit.forceEquip(spec);
       }
     }
     return outfit;

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -223,7 +223,7 @@ export class Engine<A extends string = never, T extends Task<A> = Task<A>> {
       if (this.options.allow_partial_outfits) {
         outfit.equip(spec); // ignore return value
       } else {
-        outfit.forceEquip(spec);
+        outfit.forceEquip(spec, undefined, task.name);
       }
     }
     return outfit;

--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -110,6 +110,11 @@ export type EquipResult =
       reason: string;
     };
 
+/**
+ * Create an EquipResult indicating failure.
+ *
+ * @param msg A message to explain the failure.
+ */
 function fail(msg: string): EquipResult {
   return {
     success: false,
@@ -117,6 +122,9 @@ function fail(msg: string): EquipResult {
   };
 }
 
+/**
+ * Create an EquipResult indicating success.
+ */
 function success(): EquipResult {
   return {
     success: true,
@@ -130,7 +138,7 @@ function success(): EquipResult {
 function mergeResults(results: EquipResult[]) {
   const failures = results.filter((r) => !r.success) as { reason: string }[];
   if (failures.length === 0) return success();
-  return fail(failures.map((r) => r.reason).join(" "));
+  return fail(failures.map((r) => r.reason).join(". "));
 }
 
 export class Outfit {
@@ -186,18 +194,18 @@ export class Outfit {
 
   private isAvailable(item: Item): EquipResult {
     if (this.avoid?.includes(item))
-      return fail(`Cannot equip ${item} since it is on the avoid list (${this.avoid.join(", ")}).`);
+      return fail(`Cannot equip ${item} since it is on the avoid list (${this.avoid.join(", ")})`);
     if (!have(item, this.equippedAmount(item) + 1)) {
       if (!have(item)) {
-        return fail(`Cannot equip ${item} since you do not have any.`);
+        return fail(`Cannot equip ${item} since you do not have any`);
       } else {
         return fail(
-          `Cannot equip ${item} again since you do not have ${this.equippedAmount(item) + 1}.`
+          `Cannot equip ${item} again since you do not have ${this.equippedAmount(item) + 1}`
         );
       }
     }
     if (booleanModifier(item, "Single Equip") && this.equippedAmount(item) > 0)
-      return fail(`Cannot equip ${item} again since you already have one equipped.`);
+      return fail(`Cannot equip ${item} again since you already have one equipped`);
     return success();
   }
 
@@ -213,7 +221,7 @@ export class Outfit {
     if (item !== $item.none) return fail("");
     if (slot === undefined) return success();
     if (this.equips.has(slot))
-      return fail(`Cannot equip ${item} to ${slot} since ${this.equips.get(slot)} is equipped.`);
+      return fail(`Cannot equip ${item} to ${slot} since ${this.equips.get(slot)} is equipped`);
     this.equips.set(slot, item);
     return success();
   }
@@ -221,26 +229,26 @@ export class Outfit {
   private equipNonAccessory(item: Item, slot?: Slot): EquipResult {
     if ($slots`acc1, acc2, acc3`.includes(toSlot(item))) return fail("");
     if (slot !== undefined && slot !== toSlot(item))
-      return fail(`Cannot equip ${item} to ${slot} since it is ${toSlot(item)}.`);
+      return fail(`Cannot equip ${item} to ${slot} since it is ${toSlot(item)}`);
     slot = toSlot(item);
     if (this.equips.has(slot))
-      return fail(`Cannot equip ${item} to ${slot} since ${this.equips.get(slot)} is equipped.`);
+      return fail(`Cannot equip ${item} to ${slot} since ${this.equips.get(slot)} is equipped`);
     switch (slot) {
       case $slot`off-hand`:
         if (this.equips.has($slot`weapon`) && weaponHands(this.equips.get($slot`weapon`)) !== 1) {
           return fail(
             `Cannot equip ${item} to ${slot} since the weapon ${this.equips.get(
               $slot`weapon`
-            )} is not 1-handed.`
+            )} is not 1-handed`
           );
         }
         break;
       case $slot`familiar`:
         if (this.familiar !== undefined && !canEquip(this.familiar, item))
-          return fail(`Cannot equip ${item} to ${slot} since familiar is ${this.familiar}.`);
+          return fail(`Cannot equip ${item} to ${slot} since familiar is ${this.familiar}`);
     }
     if (slot !== $slot`familiar` && !canEquip(item))
-      return fail(`Cannot equip ${item} to ${slot} since canEquip returned false.`);
+      return fail(`Cannot equip ${item} to ${slot} since canEquip returned false`);
     this.equips.set(slot, item);
     return success();
   }
@@ -249,18 +257,18 @@ export class Outfit {
     if (![undefined, ...$slots`acc1, acc2, acc3`].includes(slot)) return fail("");
     if (toSlot(item) !== $slot`acc1`) return fail("");
     if (!canEquip(item))
-      return fail(`Cannot equip ${item} as accessory since canEquip returned false.`);
+      return fail(`Cannot equip ${item} as accessory since canEquip returned false`);
     if (slot === undefined) {
       // We don't care which of the accessory slots we equip in
       const empty = $slots`acc1, acc2, acc3`.find((s) => !this.equips.has(s));
       if (empty === undefined) {
         const acc_names = $slots`acc1, acc2, acc3`.map((s) => this.equips.get(s)).join(", ");
-        return fail(`Cannot equip ${item} as accessory since ${acc_names} are all equipped.`);
+        return fail(`Cannot equip ${item} as accessory since ${acc_names} are all equipped`);
       }
       this.equips.set(empty, item);
     } else {
       if (this.equips.has(slot)) {
-        return fail(`Cannot equip ${item} to ${slot} since ${this.equips.get(slot)} is equipped.`);
+        return fail(`Cannot equip ${item} to ${slot} since ${this.equips.get(slot)} is equipped`);
       }
       this.equips.set(slot, item);
     }
@@ -274,19 +282,19 @@ export class Outfit {
       return fail(
         `Cannot dual-wield ${item} since the weapon ${this.equips.get(
           $slot`weapon`
-        )} is not 1-handed.`
+        )} is not 1-handed`
       );
     }
     if (this.equips.has($slot`off-hand`))
       return fail(
         `Cannot dual-wield ${item} since the off-hand ${this.equips.get(
           $slot`off-hand`
-        )} is equipped.`
+        )} is equipped`
       );
     if (!have($skill`Double-Fisted Skull Smashing`))
-      return fail(`Cannot dual-wield ${item} since we do not have Double-Fisted Skull Smashing.`);
-    if (weaponHands(item) !== 1) return fail(`Cannot dual-wield ${item} since it is not 1-handed.`);
-    if (!canEquip(item)) return fail(`Cannot dual-wield ${item} since canEquip returned false.`);
+      return fail(`Cannot dual-wield ${item} since we do not have Double-Fisted Skull Smashing`);
+    if (weaponHands(item) !== 1) return fail(`Cannot dual-wield ${item} since it is not 1-handed`);
+    if (!canEquip(item)) return fail(`Cannot dual-wield ${item} since canEquip returned false`);
     this.equips.set($slot`off-hand`, item);
     return success();
   }
@@ -385,17 +393,17 @@ export class Outfit {
       return fail(
         `Cannot equip ${item} with familiar since ${this.equips.get(
           $slot`familiar`
-        )} is already equipped.`
+        )} is already equipped`
       );
     if (booleanModifier(item, "Single Equip"))
       return fail(
         `Cannot equip ${item} with familiar since ${this.equips.get(
           $slot`familiar`
-        )} is already equipped.`
+        )} is already equipped`
       );
     const try_familiar = this.equipFamiliar(familiar);
     if (!try_familiar.success)
-      return fail(`Cannot equip ${item} with familiar ${familiar}; ${try_familiar.reason}.`);
+      return fail(`Cannot equip ${item} with familiar ${familiar}; ${try_familiar.reason}`);
 
     this.equips.set($slot`familiar`, item);
     return success();
@@ -419,24 +427,24 @@ export class Outfit {
       if (try_equip_method.success) return success();
       else reasons.push(try_equip_method);
     }
-    return fail(reasons.map((r) => r.reason).join(" "));
+    return fail(reasons.map((r) => r.reason).join(". "));
   }
 
   private equipFamiliar(familiar: Familiar): EquipResult {
     if (familiar === this.familiar) return success();
     if (this.familiar !== undefined)
-      return fail(`Cannot use ${familiar} since we are already using ${this.familiar}.`);
+      return fail(`Cannot use ${familiar} since we are already using ${this.familiar}`);
     if (familiar !== $familiar.none) {
-      if (!have(familiar)) return fail(`Cannot use ${familiar} since we do not own it.`);
+      if (!have(familiar)) return fail(`Cannot use ${familiar} since we do not own it`);
       for (const slot of $slots`crown-of-thrones, buddy-bjorn`) {
         if (this.riders.get(slot) === familiar) {
-          return fail(`Cannot use ${familiar} since it might be riding ${slot}.`);
+          return fail(`Cannot use ${familiar} since it might be riding ${slot}`);
         }
       }
     }
     const item = this.equips.get($slot`familiar`);
     if (item !== undefined && item !== $item.none && !canEquip(familiar, item))
-      return fail(`Cannot use ${familiar} since it cannot equip the required ${item}.`);
+      return fail(`Cannot use ${familiar} since it cannot equip the required ${item}`);
     this.familiar = familiar;
     return success();
   }
@@ -622,7 +630,7 @@ export class Outfit {
 
     if (current) {
       if (targets.includes(current)) return success();
-      else return fail(`Cannot equip ${targets} in ${slot} since ${current} is already used.`);
+      else return fail(`Cannot equip ${targets} in ${slot} since ${current} is already used`);
     }
 
     // Gather the set of riders that are equipped in other rider slots.
@@ -635,7 +643,7 @@ export class Outfit {
       this.riders.set(slot, fam);
       return success();
     }
-    return fail(`Cannot equip any of ${targets} in ${slot}.`);
+    return fail(`Cannot equip any of ${targets} in ${slot}`);
   }
 
   /**
@@ -698,7 +706,7 @@ export class Outfit {
       if (mode === "retrocape") continue; // checked below
       if (this.modes[mode] && modes[mode] && this.modes[mode] !== modes[mode]) {
         reasons.push(
-          `Mode ${mode} cannot be ${modes[mode]} since it is already ${this.modes[mode]}.`
+          `Mode ${mode} cannot be ${modes[mode]} since it is already ${this.modes[mode]}`
         );
       }
     }
@@ -712,7 +720,7 @@ export class Outfit {
         this.modes["retrocape"][0] !== modes["retrocape"][0]
       ) {
         reasons.push(
-          `Mode retrocape0 cannot be ${modes["retrocape"][0]} since it is already ${this.modes["retrocape"][0]}.`
+          `Mode retrocape0 cannot be ${modes["retrocape"][0]} since it is already ${this.modes["retrocape"][0]}`
         );
       }
 
@@ -722,7 +730,7 @@ export class Outfit {
         this.modes["retrocape"][1] !== modes["retrocape"][1]
       ) {
         reasons.push(
-          `Mode retrocape1 cannot be ${modes["retrocape"][1]} since it is already ${this.modes["retrocape"][1]}.`
+          `Mode retrocape1 cannot be ${modes["retrocape"][1]} since it is already ${this.modes["retrocape"][1]}`
         );
       }
 
@@ -735,7 +743,7 @@ export class Outfit {
       ...this.modes, // if conflict, default to the preexisting modes
     };
     if (reasons.length === 0) return success();
-    return fail(reasons.join(" "));
+    return fail(reasons.join(". "));
   }
 
   /**

--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -136,9 +136,14 @@ function success(): EquipResult {
  * Otherwise, merge all the error messages.
  */
 function mergeResults(results: EquipResult[]) {
+  if (results.find((r) => r.success)) return success();
   const failures = results.filter((r) => !r.success) as { reason: string }[];
-  if (failures.length === 0) return success();
-  return fail(failures.map((r) => r.reason).join(". "));
+  return fail(
+    failures
+      .filter((r) => r.reason !== "")
+      .map((r) => r.reason)
+      .join(". ")
+  );
 }
 
 export class Outfit {
@@ -427,7 +432,7 @@ export class Outfit {
       if (try_equip_method.success) return success();
       else reasons.push(try_equip_method);
     }
-    return fail(reasons.map((r) => r.reason).join(". "));
+    return mergeResults(reasons);
   }
 
   private equipFamiliar(familiar: Familiar): EquipResult {

--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -156,7 +156,7 @@ export class Outfit {
 
   private isAvailable(item: Item): SuccessOrReason {
     if (this.avoid?.includes(item))
-      return `Cannot equip ${item} since it is on the avoid list (${this.avoid.join(", ")})`;
+      return `Cannot equip ${item} since it is on the avoid list (${this.avoid.join(", ")}).`;
     if (!have(item, this.equippedAmount(item) + 1)) {
       if (!have(item)) {
         return `Cannot equip ${item} since you do not have any.`;
@@ -189,7 +189,7 @@ export class Outfit {
   private equipNonAccessory(item: Item, slot?: Slot): SuccessOrReason {
     if ($slots`acc1, acc2, acc3`.includes(toSlot(item))) return "";
     if (slot !== undefined && slot !== toSlot(item))
-      return `Cannot equip ${item} to ${slot} since it is ${toSlot(item)}`;
+      return `Cannot equip ${item} to ${slot} since it is ${toSlot(item)}.`;
     slot = toSlot(item);
     if (this.equips.has(slot))
       return `Cannot equip ${item} to ${slot} since ${this.equips.get(slot)} is equipped.`;
@@ -203,7 +203,7 @@ export class Outfit {
         break;
       case $slot`familiar`:
         if (this.familiar !== undefined && !canEquip(this.familiar, item))
-          return `Cannot equip ${item} to ${slot} since familiar is ${this.familiar}`;
+          return `Cannot equip ${item} to ${slot} since familiar is ${this.familiar}.`;
     }
     if (slot !== $slot`familiar` && !canEquip(item))
       return `Cannot equip ${item} to ${slot} since canEquip returned false.`;
@@ -425,9 +425,7 @@ export class Outfit {
       else this.modifier.push(spec.modifier);
     }
     if (spec.modes) {
-      if (!this.setModes(spec.modes)) {
-        reasons.push(`Modes ${spec.modes} are incompatible with current modes ${this.modes}.`);
-      }
+      reasons.push(this.setModesVerbose(spec.modes));
     }
     if (spec.riders) {
       if (spec.riders["buddy-bjorn"])

--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -117,7 +117,11 @@ function fail(msg: string): EquipResult {
   };
 }
 
-const SUCCESS: EquipResult = { success: true };
+function success(): EquipResult {
+  return {
+    success: true,
+  };
+}
 
 /**
  * Return success if any of the subcalls are success.
@@ -125,7 +129,7 @@ const SUCCESS: EquipResult = { success: true };
  */
 function mergeResults(results: EquipResult[]) {
   const failures = results.filter((r) => !r.success) as { reason: string }[];
-  if (failures.length === 0) return SUCCESS;
+  if (failures.length === 0) return success();
   return fail(failures.map((r) => r.reason).join(" "));
 }
 
@@ -194,7 +198,7 @@ export class Outfit {
     }
     if (booleanModifier(item, "Single Equip") && this.equippedAmount(item) > 0)
       return fail(`Cannot equip ${item} again since you already have one equipped.`);
-    return SUCCESS;
+    return success();
   }
 
   /**
@@ -207,11 +211,11 @@ export class Outfit {
 
   private equipItemNone(item: Item, slot?: Slot): EquipResult {
     if (item !== $item.none) return fail("");
-    if (slot === undefined) return SUCCESS;
+    if (slot === undefined) return success();
     if (this.equips.has(slot))
       return fail(`Cannot equip ${item} to ${slot} since ${this.equips.get(slot)} is equipped.`);
     this.equips.set(slot, item);
-    return SUCCESS;
+    return success();
   }
 
   private equipNonAccessory(item: Item, slot?: Slot): EquipResult {
@@ -238,7 +242,7 @@ export class Outfit {
     if (slot !== $slot`familiar` && !canEquip(item))
       return fail(`Cannot equip ${item} to ${slot} since canEquip returned false.`);
     this.equips.set(slot, item);
-    return SUCCESS;
+    return success();
   }
 
   private equipAccessory(item: Item, slot?: Slot): EquipResult {
@@ -260,7 +264,7 @@ export class Outfit {
       }
       this.equips.set(slot, item);
     }
-    return SUCCESS;
+    return success();
   }
 
   private equipUsingDualWield(item: Item, slot?: Slot): EquipResult {
@@ -284,7 +288,7 @@ export class Outfit {
     if (weaponHands(item) !== 1) return fail(`Cannot dual-wield ${item} since it is not 1-handed.`);
     if (!canEquip(item)) return fail(`Cannot dual-wield ${item} since canEquip returned false.`);
     this.equips.set($slot`off-hand`, item);
-    return SUCCESS;
+    return success();
   }
 
   private getHoldingFamiliar(item: Item): Familiar | undefined {
@@ -394,11 +398,11 @@ export class Outfit {
       return fail(`Cannot equip ${item} with familiar ${familiar}; ${try_familiar.reason}.`);
 
     this.equips.set($slot`familiar`, item);
-    return SUCCESS;
+    return success();
   }
 
   private equipItem(item: Item, slot?: Slot): EquipResult {
-    if (this.haveEquipped(item, slot)) return SUCCESS;
+    if (this.haveEquipped(item, slot)) return success();
     if (item === $item`none`) return this.equipItemNone(item, slot);
 
     const try_available = this.isAvailable(item);
@@ -412,14 +416,14 @@ export class Outfit {
       this.equipUsingFamiliar,
     ]) {
       const try_equip_method = equip_method(item, slot);
-      if (try_equip_method.success) return SUCCESS;
+      if (try_equip_method.success) return success();
       else reasons.push(try_equip_method);
     }
     return fail(reasons.map((r) => r.reason).join(" "));
   }
 
   private equipFamiliar(familiar: Familiar): EquipResult {
-    if (familiar === this.familiar) return SUCCESS;
+    if (familiar === this.familiar) return success();
     if (this.familiar !== undefined)
       return fail(`Cannot use ${familiar} since we are already using ${this.familiar}.`);
     if (familiar !== $familiar.none) {
@@ -434,7 +438,7 @@ export class Outfit {
     if (item !== undefined && item !== $item.none && !canEquip(familiar, item))
       return fail(`Cannot use ${familiar} since it cannot equip the required ${item}.`);
     this.familiar = familiar;
-    return SUCCESS;
+    return success();
   }
 
   private equipSpec(spec: OutfitSpec): EquipResult {
@@ -510,7 +514,7 @@ export class Outfit {
         const reasons = [];
         for (const element of thing) {
           const try_equip = this.equipVerbose(element, slot);
-          if (try_equip.success) return SUCCESS;
+          if (try_equip.success) return success();
           else reasons.push(try_equip);
         }
         return mergeResults(reasons);
@@ -521,7 +525,7 @@ export class Outfit {
           const result = this.equipVerbose(element);
           if (!result.success) return result;
         }
-        return SUCCESS;
+        return success();
       }
     }
     if (thing instanceof Item) return this.equipItem(thing, slot);
@@ -617,7 +621,7 @@ export class Outfit {
     const targets = Array.isArray(target) ? target : [target];
 
     if (current) {
-      if (targets.includes(current)) return SUCCESS;
+      if (targets.includes(current)) return success();
       else return fail(`Cannot equip ${targets} in ${slot} since ${current} is already used.`);
     }
 
@@ -629,7 +633,7 @@ export class Outfit {
     const fam = targets.find((f) => have(f) && this.familiar !== f && !otherRiders.includes(f));
     if (fam) {
       this.riders.set(slot, fam);
-      return SUCCESS;
+      return success();
     }
     return fail(`Cannot equip any of ${targets} in ${slot}.`);
   }
@@ -730,7 +734,7 @@ export class Outfit {
       ...modes,
       ...this.modes, // if conflict, default to the preexisting modes
     };
-    if (reasons.length === 0) return SUCCESS;
+    if (reasons.length === 0) return success();
     return fail(reasons.join(" "));
   }
 

--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -520,7 +520,7 @@ export class Outfit {
    * @param slot The slot to equip them.
    * @returns True if the thing was sucessfully equipped, or a reason why it could not be equipped.
    */
-  equipVerbose(thing: Equippable, slot?: Slot): EquipResult {
+  public equipVerbose(thing: Equippable, slot?: Slot): EquipResult {
     if (Array.isArray(thing)) {
       if (slot !== undefined) {
         // Equip the first thing in the list that is possible.
@@ -566,7 +566,7 @@ export class Outfit {
    * @param slot The slot to equip them.
    * @returns True if the thing was sucessfully equipped, and false otherwise.
    */
-  equip(thing: Equippable, slot?: Slot): boolean {
+  public equip(thing: Equippable, slot?: Slot): boolean {
     return this.equipVerbose(thing, slot).success;
   }
 
@@ -578,7 +578,7 @@ export class Outfit {
    * @param slot The slot to equip them.
    * @param context Additional context to include in the error.
    */
-  forceEquip(thing: Equippable, slot?: Slot, context?: string): void {
+  public forceEquip(thing: Equippable, slot?: Slot, context?: string): void {
     const result = this.equipVerbose(thing, slot);
     if (result.success) return;
     const contextMsg = context ? ` (${context})` : "";

--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -523,11 +523,13 @@ export class Outfit {
    *
    * @param thing The thing or things to equip.
    * @param slot The slot to equip them.
+   * @param context Additional context to include in the error.
    */
-  forceEquip(thing: Equippable, slot?: Slot): void {
+  forceEquip(thing: Equippable, slot?: Slot, context?: string): void {
     const result = this.equipVerbose(thing, slot);
     if (result === true) return;
-    throw result;
+    const contextMsg = context ? ` (${context})` : "";
+    throw `Unable to equip ${thing}${contextMsg}: ${result}`;
   }
 
   /**

--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -119,6 +119,10 @@ function fail(msg: string): EquipResult {
 
 const SUCCESS: EquipResult = { success: true };
 
+/**
+ * Return success if any of the subcalls are success.
+ * Otherwise, merge all the error messages.
+ */
 function mergeResults(results: EquipResult[]) {
   const failures = results.filter((r) => !r.success) as { reason: string }[];
   if (failures.length === 0) return SUCCESS;


### PR DESCRIPTION
This PR adds `outfit.equipVerbose` which either succeeds in equipping a thing or returns a string error message. This allows for `forceEquip` which throws the message as an error.

Internally, all the private subfunctions to modify the outfit have been changed to also return a string error message on failure.