### PR TITLE
`prepare` task before assembling combat and outfit

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -141,7 +141,13 @@ export class Engine<A extends string = never, T extends Task<A> = Task<A>> {
     const outfit = this.createOutfit(task);
 
     const task_resources = new CombatResources<A>();
+    // Create the task properly
     this.customize(task, outfit, task_combat, task_resources);
+
+    // Do all preparation actions
+    for (const resource of task_resources.all()) resource.prepare?.();
+    this.prepare(task);
+
     this.dress(task, outfit);
 
     // Prepare combat and choices
@@ -149,8 +155,6 @@ export class Engine<A extends string = never, T extends Task<A> = Task<A>> {
     this.setChoices(task, this.propertyManager);
 
     // Actually perform the task
-    for (const resource of task_resources.all()) resource.prepare?.();
-    this.prepare(task);
     this.do(task);
     while (this.shouldRepeatAdv(task)) {
       set("lastEncounter", "");


### PR DESCRIPTION
As it stands, a `prepare` action that, for example, changes the state of your inventory (by burning MP into love songs) won't have the impact of that preparation reflected in combat macro construction or in outfit construction. This seems undesirable imo.