### PR TITLE
Add context arguments to all delayed task methods

### DIFF
--- a/src/combat.ts
+++ b/src/combat.ts
@@ -228,6 +228,7 @@ export class CombatStrategy<A extends string = never, Context = void> {
    * @param resources The resources to use to fulfil actions.
    * @param defaults Macros to perform for each action without a resource.
    * @param location The adventuring location, if known.
+   * @param ctx: The current engine state to be passed to task functions.
    * @returns The compiled macro.
    */
   public compile(
@@ -273,6 +274,7 @@ export class CombatStrategy<A extends string = never, Context = void> {
   /**
    * Compile the autoattack of this combat strategy into a complete macro.
    *
+   * @param ctx: The current engine state to be passed to task functions.
    * @returns The compiled autoattack macro.
    */
   public compileAutoattack(ctx: Context): Macro {

--- a/src/combat.ts
+++ b/src/combat.ts
@@ -6,7 +6,7 @@ import { Delayed, Macro, undelay } from "libram";
  * The function will be called after the outfit has been equipped,
  * but before any task-specific preparation.
  */
-export type DelayedMacro<Context> = Delayed<Macro, [Context]>;
+export type DelayedMacro<Context = void> = Delayed<Macro, [Context]>;
 
 /**
  * The strategy to use for combat for a task, which indicates what to do

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -85,6 +85,11 @@ export abstract class ContextualEngine<
     this.initPropertiesManager(this.propertyManager);
   }
 
+  /**
+   * Compute the current engine state, to be passed to task functions.
+   *
+   * This will generally be called once per task execution.
+   */
   public abstract getContext(): Context;
 
   /**

--- a/src/limit.ts
+++ b/src/limit.ts
@@ -13,18 +13,18 @@ import { get } from "libram";
  *    returned inner function is run after the task executes.
  * @member message An extra message to include with the error.
  */
-export type Limit = {
+export type Limit<Context> = {
   tries?: number;
   turns?: number;
   soft?: number;
   skip?: number;
   unready?: boolean;
   completed?: boolean;
-  guard?: Guard;
+  guard?: Guard<Context>;
   message?: string;
 };
 
-export type Guard = () => () => boolean;
+export type Guard<Context> = (ctx: Context) => () => boolean;
 
 export class Guards {
   /**
@@ -33,7 +33,7 @@ export class Guards {
    * @param before
    * @param after
    */
-  static create<T>(before: () => T, after: (old: T) => boolean): Guard {
+  static create<T>(before: () => T, after: (old: T) => boolean): Guard<void> {
     return () => {
       const old = before();
       return () => after(old);
@@ -45,7 +45,7 @@ export class Guards {
    * @param condition A condition that should return true if the task
    *    sucessfully executed.
    */
-  static after(condition: () => boolean): Guard {
+  static after(condition: () => boolean): Guard<void> {
     return () => condition;
   }
 
@@ -53,7 +53,7 @@ export class Guards {
    * A guard that asserts the provided property changed.
    * @param property The property to check.
    */
-  static changed(property: string): Guard {
+  static changed(property: string): Guard<void> {
     return this.create<string>(
       () => get(property),
       (old: string) => get(property) !== old,

--- a/src/task.ts
+++ b/src/task.ts
@@ -21,6 +21,15 @@ export type AcquireItem<Context = void> = {
   get?: (ctx: Context) => void;
 };
 
+/**
+ * A single script step or action to take.
+ *
+ * Most scripts will not need to change the generic parameters from the default
+ * values; they are only needed for advanced use cases.
+ *
+ * @param A The set of combat placeholder actions.
+ * @param Context The type for global state passed from the engine (@see ContextualEngine).
+ */
 export type Task<A extends string = never, Context = void> = {
   name: string;
   after?: string[];

--- a/src/task.ts
+++ b/src/task.ts
@@ -53,7 +53,7 @@ export type StrictCombatTask<
 > = Omit<Task<A, Context>, "do" | "combat" | "outfit"> &
   (
     | {
-        do: Delayed<Location> | ((context: Context) => void);
+        do: Delayed<Location, [Context]> | ((context: Context) => void);
         combat: C;
         outfit: Delayed<O>;
       }

--- a/src/task.ts
+++ b/src/task.ts
@@ -5,58 +5,59 @@ import { CombatStrategy } from "./combat";
 import { Limit } from "./limit";
 import { Outfit, OutfitSpec } from "./outfit";
 
-export type Quest<T> = {
+export type Quest<T, Context = void> = {
   name: string;
-  completed?: () => boolean;
-  ready?: () => boolean;
+  completed?: (ctx: Context) => boolean;
+  ready?: (ctx: Context) => boolean;
   tasks: T[];
 };
 
-export type AcquireItem = {
+export type AcquireItem<Context = void> = {
   item: Item;
   num?: number;
   price?: number;
-  useful?: () => boolean;
+  useful?: (ctx: Context) => boolean;
   optional?: boolean;
-  get?: () => void;
+  get?: (ctx: Context) => void;
 };
 
-export type Task<A extends string = never> = {
+export type Task<A extends string = never, Context = void> = {
   name: string;
   after?: string[];
 
-  ready?: () => boolean;
-  completed: () => boolean;
+  ready?: (ctx: Context) => boolean;
+  completed: (ctx: Context) => boolean;
 
   // How to perform the task
   // Executed as:
   //  1. prepare();
   //  2. adv1(do) OR do();
   //  3. post();
-  prepare?: () => void;
-  do: Location | (() => Location) | (() => void);
-  post?: () => void;
+  prepare?: (ctx: Context) => void;
+  do: Location | ((ctx: Context) => Location) | ((context: Context) => void);
+  post?: (ctx: Context) => void;
 
-  acquire?: Delayed<AcquireItem[]>;
-  effects?: Delayed<Effect[]>;
-  choices?: Delayed<{ [id: number]: number | string }>;
-  limit?: Limit;
-  outfit?: Delayed<OutfitSpec | Outfit>;
-  combat?: CombatStrategy<A>;
+  acquire?: Delayed<AcquireItem[], [Context]>;
+  effects?: Delayed<Effect[], [Context]>;
+  choices?: Delayed<{ [id: number]: number | string }, [Context]>;
+  limit?: Limit<Context>;
+  outfit?: Delayed<OutfitSpec | Outfit, [Context]>;
+  combat?: CombatStrategy<A, Context>;
 };
 
 export type StrictCombatTask<
   A extends string = never,
   C extends CombatStrategy<A> = CombatStrategy<A>,
   O extends OutfitSpec | Outfit = OutfitSpec | Outfit,
-> = Omit<Task, "do" | "combat" | "outfit"> &
+  Context = void,
+> = Omit<Task<A, Context>, "do" | "combat" | "outfit"> &
   (
     | {
-        do: Delayed<Location> | (() => void);
+        do: Delayed<Location> | ((context: Context) => void);
         combat: C;
         outfit: Delayed<O>;
       }
-    | { do: () => void; outfit?: Delayed<O> }
+    | { do: () => void; outfit?: Delayed<O, [Context]> }
   );
 
 /**


### PR DESCRIPTION
This PR adds a "context" produced by the Engine that can be consumed by all of the methods on a task (ready, completed, delayed combat macros, etc.). Contexts are designed to be computed once per task execution, and can be used for tasks to consider global state when needed.

This could be used to avoid globals like the [globalStateCache ](https://github.com/Kasekopf/loopstar/blob/76a4fc46500c4e50b0bc0748377afbef1ca31096/src/engine/state.ts#L126) in loopstar, or to store mine state in oreo.

Typescript is pretty cool about the Void type, so I think this is basically entirely backwards compatible for grimoire scripts.